### PR TITLE
Login fix

### DIFF
--- a/src/classes/system/model.class.php
+++ b/src/classes/system/model.class.php
@@ -974,7 +974,7 @@ class Model extends HTML {
 	function isEmail($name) {
 
 		$value = $this->getProperty($name, "value");
-		$pattern = stringOr($this->getProperty($name, "pattern"), "^[\w\.\-\_]+@[\w-\.]+\.\w{2,10}$");
+		$pattern = stringOr($this->getProperty($name, "pattern"), "^[\w\.\-\_\+]+@[\w-\.]+\.\w{2,10}$");
 
 		if($value && is_string($value) && 
 			(!$pattern || preg_match("/".$pattern."/", $value))

--- a/src/templates/pages/forgot_password.php
+++ b/src/templates/pages/forgot_password.php
@@ -21,7 +21,7 @@ $this->pageTitle("Forgot password?");
 <?	endif; ?>
 
 		<fieldset>
-			<?= $model->input("username", array("type" => "string", "label" => "Email", "required" => true, "pattern" => "[\w\.\-_]+@[\w\-\.]+\.\w{2,10}", "hint_message" => "Type your email.", "error_message" => "Invalid email.")); ?>
+			<?= $model->input("username", array("type" => "string", "label" => "Email", "required" => true, "pattern" => "[\w\.\-_\+]+@[\w\-\.]+\.\w{2,10}", "hint_message" => "Type your email.", "error_message" => "Invalid email.")); ?>
 		</fieldset>
 
 		<ul class="actions">


### PR DESCRIPTION
in Login process:
Added control over the case of a User Group NOT having Access assigned.
Now, when a User that belongs to such Group tries to Login, the correct message will be shown.
"Your User Group (GROUPNAME) has no permissions, please contact administration."