### PR TITLE
Update sindex on update if sindexBase is set

### DIFF
--- a/src/classes/items/itemtype.core.class.php
+++ b/src/classes/items/itemtype.core.class.php
@@ -463,21 +463,15 @@ class ItemtypeCore extends Model {
 					}
 
 
-					// $sindex = false;
-					// // look for local sindex method
-					// // implement sindexBase function in your itemtype class to use special sindexes
-					// if(method_exists($this, "sindexBase")) {
-					// 	$sindex = $this->sindexBase($item_id);
-					// }
-					// // Use name as default
-					// else if(array_search("name", $names) !== false) {
-					// 	$sindex = $entities["name"]["value"];
-					// }
-					//
-					// // create new sindex
-					// if($sindex) {
-					// 	$this->sindex($sindex, $item_id);
-					// }
+					$sindex = false;
+					// if sindexBase is implemented, use the overridden sindex naming scheme:
+					if (method_exists($this, "sindexBase")) {
+						$sindex = $this->sindexBase($item_id);
+					}
+					// update sindex
+					if ($sindex) {
+						$this->sindex($sindex, $item_id);
+					}
 
 
 					// itemtype post update handler?


### PR DESCRIPTION
This is complementary to [this pull request on the kbhff_dk repository](https://github.com/kbhff/kbhff_dk/pull/15).

We want to make it so that if you duplicate an existing bag (e.g. from a template) and update the week number, then it will also update the sindex. Currently the sindex is e.g. "uge-23-copied".

This pull request changes the update method to check whether `sindexBase` is implemented on the item type, and if so, use it to recalculate the sindex. The `ItemtypeCore.save` method already uses `sindexBase` for this purpose.